### PR TITLE
Default to select if payload is known

### DIFF
--- a/app/assets/javascripts/rules.js
+++ b/app/assets/javascripts/rules.js
@@ -7,10 +7,10 @@ $('[data-handler-list]').on('change', '[data-handler]', function (event) {
 
     if ($element.attr('data-handler-details') == handler) {
       $element.show();
-      $element.find('input').prop('disabled', false);
+      $element.find(':input').prop('disabled', false);
     } else {
       $element.hide();
-      $element.find('input').prop('disabled', true);
+      $element.find(':input').prop('disabled', true);
     }
   });
 })
@@ -25,6 +25,22 @@ $('[data-topic]').on('change', function (event) {
     if ($element.attr('data-topic-payload') == topic) {
       $element.show();
     } else {
+      $element.hide();
+    }
+  });
+
+  $('[data-topic-filter-value]').each(function (index, element) {
+    var $element = $(element);
+    var $f_value = $element.siblings('[data-filter-value]');
+
+    $f_value.show().prop('disabled', false);
+
+    if ($element.attr('data-topic-filter-value') == topic) {
+      $f_value.hide().prop('disabled', true);
+      $element.find(':input').prop('disabled', false);
+      $element.show();
+    } else {
+      $element.find(':input').prop('disabled', true);
       $element.hide();
     }
   });

--- a/app/helpers/rules_helper.rb
+++ b/app/helpers/rules_helper.rb
@@ -1,2 +1,23 @@
 module RulesHelper
+  def payload_to_values(payload)
+    flatten_payload_values(payload).map do |key, value|
+      [key, "{{ #{key} }}", { data: { type: value.to_s } }]
+    end
+  end
+
+  def flatten_payload_values(payload, prefix = nil)
+    if payload.is_a?(Hash)
+      payload.map do |key, value|
+        next if value.is_a?(Array)
+
+        if prefix
+          flatten_payload_values(value, "#{prefix}.#{key}")
+        else
+          flatten_payload_values(value, key)
+        end
+      end.compact.reduce(&:merge)
+    else
+      { prefix => payload }
+    end
+  end
 end

--- a/app/views/rules/_filter.html.erb
+++ b/app/views/rules/_filter.html.erb
@@ -6,7 +6,13 @@
 
     <%= f.hidden_field :_destroy, value: local_assigns.fetch(:destroyed, false) %>
     <%= f.label :value, 'Field' %>
-    <%= f.text_field :value, placeholder: 'Example: {{ default_address.company }}' %>
+    <%= f.text_field :value, placeholder: 'Example: {{ default_address.company }}', data: { 'filter-value': true } %>
+
+    <% Schema.describe.each do |key, payload| %>
+      <div class="select-wrapper" data-topic-filter-value="<%= key %>" style="display: none;">
+        <%= f.select :value, payload_to_values(payload), { prompt: 'Value' }, { class: 'select', disabled: true } %>
+      </div>
+    <% end %>
 
     <%= f.label :verb %>
     <div class="select-wrapper">

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -36,7 +36,7 @@
 
         <div style="display: none;" data-filter-template>
           <%= f.fields_for :filters, Filter.new do |ff| %>
-            <%= render 'filter', f: ff, destroyed: true, disabled: true %>
+            <%= render 'filter', f: ff, destroyed: true %>
           <% end %>
         </div>
       <p>
@@ -60,7 +60,7 @@
 
         <div style="display: none;" data-handler-template>
           <%= f.fields_for :handlers, Handler.new do |ff| %>
-            <%= render 'handler', f: ff, destroyed: true, disabled: true %>
+            <%= render 'handler', f: ff, destroyed: true %>
           <% end %>
         </div>
       <p>


### PR DESCRIPTION
For filter values, if webhook's payload is known, we can default to a hash instead of asking for text input, since it has to match 1-to-1 with a known attribute.

Hence from now on, if webhook's topic has a known payload, we'll now show a dropdown as follow;
<img width="591" alt="screen shot 2016-06-26 at 12 14 43 pm" src="https://cloud.githubusercontent.com/assets/596120/16363433/eb37eabe-3b97-11e6-91d7-b34636425157.png">

On the other hand, if we were too lazy to upload the payload, we still default to a free-from text input;
<img width="740" alt="screen shot 2016-06-26 at 12 16 12 pm" src="https://cloud.githubusercontent.com/assets/596120/16363435/eda40972-3b97-11e6-8e0f-c493b1e8a0bf.png">

@tjoyal 
