### PR TITLE
[Handlers] Patch UX missing validation error

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -49,10 +49,7 @@ class RulesController < AuthenticatedController
   def rule_params
     rule = params.require(:rule)
     rule = rule.permit(:name, :topic, handlers_attributes: [:id, :service_name, :_destroy], filters_attributes: [:id, :value, :verb, :regex, :_destroy])
-    rule[:handlers_attributes].each do |k, _v|
-      rule[:handlers_attributes][k][:settings] = params[:rule][:handlers_attributes][k][:settings].to_unsafe_h
-    end
-    rule
+    rule.to_unsafe_h
   end
 
   def sync_webhooks


### PR DESCRIPTION
Temporary patch a UX error when adding a handler without selecting the type leading to the setting block to not be set, resulting in a call to `to_unsafe_h` over a `nil` object.

Eg.:
<img width="1431" alt="Screen Shot 2020-03-12 at 8 46 29 AM" src="https://user-images.githubusercontent.com/207902/76523037-11f15500-643e-11ea-864c-63fe75088e74.png">

Real fix would be to properly permit and validate the data as input.

cc @christianblais 