### PR TITLE
[Handler] Migrate settings as nullable column

### DIFF
--- a/app/models/handler.rb
+++ b/app/models/handler.rb
@@ -14,11 +14,7 @@ class Handler < ActiveRecord::Base
   validates :rule, presence: true
   validates :service_name, presence: true, inclusion: HANDLERS.keys.map(&:to_s)
 
-  serialize :settings
-
-  def settings
-    super || {}
-  end
+  serialize :settings, Hash
 
   def service
     service_name.constantize

--- a/db/migrate/20200312123853_handlers_settings_as_nullable.rb
+++ b/db/migrate/20200312123853_handlers_settings_as_nullable.rb
@@ -1,0 +1,13 @@
+class HandlersSettingsAsNullable < ActiveRecord::Migration[5.2]
+  def up
+    # https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
+    # Empty objects as {}, in the case of Hash, or [], in the case of Array, will always be persisted as null.
+    #
+    # We still need to figure out the validation layer, but this change makes it align with the expected rails behaviour of `serialize`
+    change_column :handlers, :settings, :text, null: true
+  end
+
+  def down
+    change_column :handlers, :settings, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_06_10_141519) do
+ActiveRecord::Schema.define(version: 2020_03_12_123853) do
 
   create_table "filters", force: :cascade do |t|
     t.integer "rule_id", null: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2016_06_10_141519) do
   create_table "handlers", force: :cascade do |t|
     t.integer "rule_id", null: false
     t.string "service_name", null: false
-    t.text "settings", null: false
+    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["rule_id"], name: "index_handlers_on_rule_id"


### PR DESCRIPTION
https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize

> Empty objects as {}, in the case of Hash, or [], in the case of Array, will always be persisted as null.

There does not seems to be a clean going around it. `{}` is persisted as `nil` and 💥 

This is somewhat of a stop-gap measure. We need to iterate on validation so it is not possible in the first place to not provide mandatory settings to handlers. That being said if a handler didn't had mandatory settings (would that be possible?) the same problem would occur.

cc @christianblais 