### PR TITLE
[Handlers] Move labels to implementations

### DIFF
--- a/app/helpers/rules_helper.rb
+++ b/app/helpers/rules_helper.rb
@@ -22,10 +22,10 @@ module RulesHelper
   end
 
   def available_handlers
-    current_shop_handlers = shop.rules.map { |r| r.handlers.map { |h| h.service_name } }.flatten.uniq
+    current_shop_handlers = shop.rules.joins(:handlers).select('handlers.service_name').distinct
 
     Handler::HANDLERS.reject do |handler|
-      handler.deprecated? && !current_shop_handlers.include?(handler.to_s)
+      handler.deprecated? && current_shop_handlers.exclude?(handler.to_s)
     end
   end
 end

--- a/app/helpers/rules_helper.rb
+++ b/app/helpers/rules_helper.rb
@@ -20,4 +20,12 @@ module RulesHelper
       { prefix => payload }
     end
   end
+
+  def available_handlers
+    current_shop_handlers = shop.rules.map { |r| r.handlers.map { |h| h.service_name } }.flatten.uniq
+
+    Handler::HANDLERS.reject do |handler|
+      handler.deprecated? && !current_shop_handlers.include?(handler.to_s)
+    end
+  end
 end

--- a/app/models/handler.rb
+++ b/app/models/handler.rb
@@ -1,18 +1,18 @@
 class Handler < ActiveRecord::Base
-  HANDLERS = {
-    Handlers::Tagger => 'Add a tag to a Shopify resource',
-    Handlers::DatadogEvent => 'Send a Datadog event',
-    Handlers::Slack => 'Send a message on Slack',
-    Handlers::SMS => 'Send a SMS (via Twillio)',
-    Handlers::Twitter => 'Send a tweet',
-    Handlers::Emailer => 'Send an email (Test only)',
-    Handlers::SendGrid => 'Send an email (via SendGrid)',
-  }
+  HANDLERS = [
+    Handlers::Tagger,
+    Handlers::DatadogEvent,
+    Handlers::Slack,
+    Handlers::SMS,
+    Handlers::Twitter,
+    Handlers::Emailer,
+    Handlers::SendGrid,
+  ]
 
   belongs_to :rule, inverse_of: :handlers
 
   validates :rule, presence: true
-  validates :service_name, presence: true, inclusion: HANDLERS.keys.map(&:to_s)
+  validates :service_name, presence: true, inclusion: HANDLERS.map(&:to_s)
 
   serialize :settings, Hash
 

--- a/app/models/handlers/base.rb
+++ b/app/models/handlers/base.rb
@@ -11,6 +11,14 @@ module Handlers
         @description
       end
 
+      def deprecated!
+        @deprecated = true
+      end
+
+      def deprecated?
+        !!@deprecated
+      end
+
       def settings
         @settings ||= {}
       end

--- a/app/models/handlers/base.rb
+++ b/app/models/handlers/base.rb
@@ -1,6 +1,11 @@
 module Handlers
   class Base
     class << self
+      def label(label = nil)
+        @label = label if label
+        @label
+      end
+
       def description(description = nil)
         @description = description if description
         @description

--- a/app/models/handlers/datadog_event.rb
+++ b/app/models/handlers/datadog_event.rb
@@ -1,5 +1,7 @@
 module Handlers
   class DatadogEvent < Base
+    label 'Send a Datadog event'
+
     description %(
       Use the Datadog API to send custom events.
       <a href="https://github.com/christianblais/triggerify/wiki/Rule-Action-Datadog-Event" target="_blank">More information</a>

--- a/app/models/handlers/emailer.rb
+++ b/app/models/handlers/emailer.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Emailer < Base
+    label 'Send an email (Test only)'
+
     description %(
       Note that this is for test purposes only. No guaranteed delivery whatsoever.
       For real email deliveries, please use SendGrid with your own API key.

--- a/app/models/handlers/send_grid.rb
+++ b/app/models/handlers/send_grid.rb
@@ -1,5 +1,7 @@
 module Handlers
   class SendGrid < Base
+    label 'Send an email (via SendGrid)'
+
     description %(
       Use the SendGrid API to send an email.
       <a href="https://github.com/christianblais/triggerify/wiki/Rule-Action-Email-SendGrid" target="_blank">More information</a>

--- a/app/models/handlers/slack.rb
+++ b/app/models/handlers/slack.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Slack < Base
+    label 'Send a message on Slack'
+
     description %(
       Use the Slack API to send a message.
       <a href="https://get.slack.help/hc/en-us/articles/215770388-Create-and-regenerate-API-tokens" target="_blank">Click here</a>

--- a/app/models/handlers/slack.rb
+++ b/app/models/handlers/slack.rb
@@ -8,6 +8,8 @@ module Handlers
       for more information.
     )
 
+    deprecated!
+
     setting :slack_token,
       name: 'Slack api permission token',
       example: '2e1bad1377ff7faaae75a46f51663531'

--- a/app/models/handlers/sms.rb
+++ b/app/models/handlers/sms.rb
@@ -1,5 +1,7 @@
 module Handlers
   class SMS < Base
+    label 'Send a SMS (via Twillio)'
+
     description %(
       Use the Twillio API to send a SMS.
       <a href="https://github.com/christianblais/triggerify/wiki/Rule-Action-SMS-Twillio" target="_blank">More information</a>

--- a/app/models/handlers/tagger.rb
+++ b/app/models/handlers/tagger.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Tagger < Base
+    label 'Add a tag to a Shopify resource'
+
     description %(
       Add a tag to Shopify resource on your store.
       <a href="https://github.com/christianblais/triggerify/wiki/Rule-Action-Shopify-Tag" target="_blank">More information</a>

--- a/app/models/handlers/twitter.rb
+++ b/app/models/handlers/twitter.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Twitter < Base
+    label 'Send a tweet'
+
     description %(
       Use the Twitter API to send a tweet.
       <a href="https://github.com/christianblais/triggerify/wiki/Rule-Action-Twitter" target="_blank">More information</a>

--- a/app/views/rules/_handler.html.erb
+++ b/app/views/rules/_handler.html.erb
@@ -8,11 +8,11 @@
 
     <%= f.label :service_name, 'Action' %>
     <div class="select-wrapper">
-      <%= f.select :service_name, Handler::HANDLERS.map { |handler| [handler.label, handler.to_s] }, { prompt: "Select an action" }, { class: 'select', data: { handler: true } } %>
+      <%= f.select :service_name, available_handlers.map { |handler| [handler.label, handler.to_s] }, { prompt: "Select an action" }, { class: 'select', data: { handler: true } } %>
     </div>
 
     <%= f.fields_for :settings do |ff| %>
-      <% Handler::HANDLERS.each do |handler| %>
+      <% available_handlers.each do |handler| %>
         <div data-handler-details="<%= handler %>">
           <% if handler.description.present? %>
             <p><%= raw(handler.description) %></p>

--- a/app/views/rules/_handler.html.erb
+++ b/app/views/rules/_handler.html.erb
@@ -8,11 +8,11 @@
 
     <%= f.label :service_name, 'Action' %>
     <div class="select-wrapper">
-      <%= f.select :service_name, Handler::HANDLERS.map { |k, v| [v, k.to_s] }, { prompt: "Select an action" }, { class: 'select', data: { handler: true } } %>
+      <%= f.select :service_name, Handler::HANDLERS.map { |handler| [handler.label, handler.to_s] }, { prompt: "Select an action" }, { class: 'select', data: { handler: true } } %>
     </div>
 
     <%= f.fields_for :settings do |ff| %>
-      <% Handler::HANDLERS.keys.each do |handler| %>
+      <% Handler::HANDLERS.each do |handler| %>
         <div data-handler-details="<%= handler %>">
           <% if handler.description.present? %>
             <p><%= raw(handler.description) %></p>


### PR DESCRIPTION
Deprecating slack as it is no longer possible to generate legacy authentication token.

More work will be required if we want to maintain slack by creating a second handler class that can use oauth.

We need to maintain the slack handler for the time being as users with existing tokens can still use it.

Shop with an existing slack handlers to keep access to it. Removing from other shop visibility to reduce confusion.