### PR TITLE
[SyncWebhookJob] Only sync enabled rules

### DIFF
--- a/app/jobs/sync_webhook_job.rb
+++ b/app/jobs/sync_webhook_job.rb
@@ -33,6 +33,6 @@ class SyncWebhookJob < ShopJob
   end
 
   def desired_topics
-    shop.rules.all.distinct(:topic).pluck(:topic).push('app/uninstalled')
+    shop.rules.where(enabled: true).distinct(:topic).pluck(:topic).push('app/uninstalled')
   end
 end


### PR DESCRIPTION
Otherwise Triggerify receives webhooks for past enabled rules we no longer need to receive.