### PR TITLE
[HandlersEmail] Remove from option

### DIFF
--- a/app/models/handlers/emailer.rb
+++ b/app/models/handlers/emailer.rb
@@ -12,10 +12,6 @@ module Handlers
       name: 'List of recipient email addresses',
       example: 'test@example.com, another@test.com'
 
-    setting :from,
-      name: 'Email address this email is sent from',
-      example: 'my.name@something.com'
-
     setting :subject,
       name: 'Title of the email',
       example: 'Hello {{ first_name }}!'
@@ -34,7 +30,7 @@ module Handlers
         :authentication => :plain,
       }
 
-      HandlerMailer.email(to: recipients, from: 'no-reply@email.com', subject: subject, body: body).deliver_now!
+      HandlerMailer.email(to: recipients, from: "triggerify@#{ENV['MAILGUN_DOMAIN']}", subject: subject, body: body).deliver_now!
     end
   end
 end


### PR DESCRIPTION
It is still unclear to me why we have been allowed so far to send emails as "no-reply@email.com". Removing this in favour or explicitly using the validated domain.

The from clause was never being used either.