### PR TITLE
[Sendgrid] Move from smtp to api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem 'twilio-ruby'
 gem 'slack-ruby-client'
 gem 'dogapi'
 gem 'twitter'
+gem 'sendgrid-ruby'
+
 gem 'shopify_app', '~> 13'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,10 @@ GEM
     rake (13.0.1)
     redirect_safely (1.0.0)
       activemodel
+    ruby_http_client (3.5.1)
     semantic_range (2.3.0)
+    sendgrid-ruby (6.3.4)
+      ruby_http_client (~> 3.4)
     shopify_api (9.1.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
@@ -277,6 +280,7 @@ DEPENDENCIES
   puma
   rails (~> 6)
   rails_12factor
+  sendgrid-ruby
   shopify_app (~> 13)
   skylight
   slack-ruby-client

--- a/app/models/handlers/send_grid.rb
+++ b/app/models/handlers/send_grid.rb
@@ -1,5 +1,7 @@
 module Handlers
   class SendGrid < Base
+    class DeliveryError < StandardError; end
+
     label 'Send an email (via SendGrid)'
 
     description %(
@@ -28,16 +30,28 @@ module Handlers
       example: 'This is an email from triggerify!'
 
     def call
-      HandlerMailer.smtp_settings = {
-        :port           => 587,
-        :address        => 'smtp.sendgrid.net',
-        :domain         => 'triggerify.herokuapp.com',
-        :user_name      => 'apikey',
-        :password       => api_key,
-        :authentication => :plain,
-      }
+      mail = ::SendGrid::Mail.new
+      mail.from = ::SendGrid::Email.new(email: from)
 
-      HandlerMailer.email(to: recipients, from: from, subject: subject, body: body).deliver_now!
+      personalization = ::SendGrid::Personalization.new
+      recipients.split(",").each do |recipient|
+        personalization.add_to(::SendGrid::Email.new(email: recipient.strip))
+      end
+      mail.add_personalization(personalization)
+
+      mail.subject = subject
+      mail.add_content(::SendGrid::Content.new(type: 'text/plain', value: body))
+
+      sg = ::SendGrid::API.new(api_key: api_key)
+      response = sg.client.mail._('send').post(request_body: mail.to_json)
+
+      Rails.logger.info "Status: #{response.status_code}"
+      Rails.logger.info "Body: #{response.body}"
+      Rails.logger.info "Headers: #{response.headers}"
+
+      if response.status_code.to_i != 202
+        raise DeliveryError, "Error code: #{response.status_code}. #{response.body}"
+      end
     end
   end
 end


### PR DESCRIPTION
The API is very verbose (and arguably very weird...), but it gives us a much larger control over what is happening.

I've 🎩  in dev with single and multiple to targets.

This change allows us to log more information about the operation. 

This PR does not take care of whitelisting errors that aren't under our control and we would still log to Bugsnag if for example an api token is not valid. I plan to iterate on silencing errors we cannot deal with ourselves as we do elsewhere in a followup PR.

I'd also like to migrate away from SMTP integration for test emails.