### PR TITLE
[Emailer] Switch to sendgrid

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,3 +8,7 @@ SHOPIFY_CLIENT_API_SECRET=
 # These are to be set in production only
 BUGSNAG_API_KEY=
 SKYLIGHT_AUTHENTICATION=
+
+# EmailHandler
+HANDLER_EMAILER_FROM="test+dev@triggerify.ca"
+HANDLER_EMAILER_API_KEY=

--- a/app/models/handlers/emailer.rb
+++ b/app/models/handlers/emailer.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Emailer < Base
+    class DeliveryError < StandardError; end
+
     label 'Send an email (Test only)'
 
     description %(
@@ -21,16 +23,28 @@ module Handlers
       example: 'This is an email from Triggerify!'
 
     def call
-      ActionMailer::Base.smtp_settings = {
-        :port           => ENV['MAILGUN_SMTP_PORT'],
-        :address        => ENV['MAILGUN_SMTP_SERVER'],
-        :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
-        :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-        :domain         => ENV['MAILGUN_DOMAIN'],
-        :authentication => :plain,
-      }
+      mail = ::SendGrid::Mail.new
+      mail.from = ::SendGrid::Email.new(email: ENV.fetch('HANDLER_EMAILER_FROM'))
 
-      HandlerMailer.email(to: recipients, from: "triggerify@#{ENV['MAILGUN_DOMAIN']}", subject: subject, body: body).deliver_now!
+      personalization = ::SendGrid::Personalization.new
+      recipients.split(",").each do |recipient|
+        personalization.add_to(::SendGrid::Email.new(email: recipient.strip))
+      end
+      mail.add_personalization(personalization)
+
+      mail.subject = subject
+      mail.add_content(::SendGrid::Content.new(type: 'text/plain', value: body))
+
+      sg = ::SendGrid::API.new(api_key: ENV.fetch('HANDLER_EMAILER_API_KEY'))
+      response = sg.client.mail._('send').post(request_body: mail.to_json)
+
+      Rails.logger.info "Status: #{response.status_code}"
+      Rails.logger.info "Body: #{response.body}"
+      Rails.logger.info "Headers: #{response.headers}"
+
+      if response.status_code.to_i != 202
+        raise DeliveryError, "Error code: #{response.status_code}. #{response.body}"
+      end
     end
   end
 end


### PR DESCRIPTION
WIP: Waiting for Heroku information on SendGrid pricing.

Moving away from MailGun, unifying the code backend.

Env configuration become much simpler with a `HANDLER_EMAILER_API_KEY` for the SendGrid account, and `HANDLER_EMAILER_FROM` for the hardcoded "From" which will be a validated sender within the SendGrid account attached (eg.: `demo@triggerify.ca`).


