### PR TITLE
Silence user errors

### DIFF
--- a/app/models/handlers/tagger.rb
+++ b/app/models/handlers/tagger.rb
@@ -1,5 +1,7 @@
 module Handlers
   class Tagger < Base
+    class ResourceNotFoundError < StandardError; end
+
     label 'Add a tag to a Shopify resource'
 
     description %(
@@ -22,12 +24,27 @@ module Handlers
 
     def call
       resource_class = "ShopifyAPI::#{taggable_type}".classify.constantize
-      resource = resource_class.find(taggable_id)
+      resource = find_taggable(resource_class, taggable_id)
       tags = resource.tags.split(',').map(&:strip)
-      return if tags.include?(tag_name.strip)
+
+      if tags.include?(tag_name.strip)
+        Rails.logger.info("Tagger tag already present: skip")
+        return
+      end
+
       tags.push(tag_name)
       resource.tags = tags.join(',')
       resource.save
+    rescue ResourceNotFoundError > e
+      Rails.logger.info("Tagger silenced error: #{e.message}")
+    end
+
+    private
+
+    def find_taggable(resource_class, taggable_id)
+      resource_class.find(taggable_id)
+    rescue ActiveResource::ResourceNotFound > e
+      raise ResourceNotFoundError, e.message
     end
   end
 end


### PR DESCRIPTION
There should be some tests, and more importantly some user feedback, for now I'll simply silence them until decisions are made so we can production monitoring focus on unexpected exceptions.