### PR TITLE
Bump bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,4 +401,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.3.7


### PR DESCRIPTION
Remove deprecation warning:

> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.