### PR TITLE
Remove Rails' custom html around errors

### DIFF
--- a/config/initializers/field_error_proc.rb
+++ b/config/initializers/field_error_proc.rb
@@ -1,0 +1,3 @@
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  html_tag
+end


### PR DESCRIPTION
@tjoyal this should fix it, I forgot to include it in the previous PR. Unfortunately, this is at the app level, and not per form builder (which sucks). But hey, it works?

Other option would be to do something like;


```ruby
module CustomFormFor
  def custom_form_for(*args, &block)
    original_field_error_proc = ::ActionView::Base.field_error_proc
    ::ActionView::Base.field_error_proc = -> (html_tag, instance) { html_tag }
    form_for(*args, &block)
  ensure
    ::ActionView::Base.field_error_proc = original_field_error_proc
  end
end

ActiveSupport.on_load(:action_view) do
  include CustomFormFor
end
```

But hey... the simpler the better?