### PR TITLE
[Rule] Keep last events

### DIFF
--- a/app/jobs/callback_webhook_job.rb
+++ b/app/jobs/callback_webhook_job.rb
@@ -10,13 +10,10 @@ class CallbackWebhookJob < ShopJob
   private
 
   def process_rule(rule, callback)
-    return unless rule.filters.all? do |filter|
-      FilterValidator.new(filter).valid?(callback)
-    end
-
-    rule.handlers.each do |handler|
-      handler.handle(callback)
-    end
+    RuleRunner.new(
+      rule: rule,
+      callback: callback
+    ).perform
   rescue StandardError => e
     report_exception(e) do |report|
       report.add_tab(:rule, {

--- a/app/models/handler.rb
+++ b/app/models/handler.rb
@@ -26,11 +26,9 @@ class Handler < ActiveRecord::Base
 
     begin
       instance.call
-    rescue Handlers::UserError => e
-      Rails.logger.info("User error: #{e.message}")
+    ensure
+      Handler.increment_counter(:handle_count, id, touch: true)
     end
-  ensure
-    Handler.increment_counter(:handle_count, id, touch: true)
   end
 
   private

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -46,6 +46,8 @@ class Rule < ActiveRecord::Base
     'themes/publish' => 'Theme publish',
   }
 
+  EVENTS_TO_KEEP = 10
+
   belongs_to :shop
   has_many :filters, dependent: :destroy, inverse_of: :rule
   has_many :handlers, dependent: :destroy, inverse_of: :rule
@@ -53,8 +55,18 @@ class Rule < ActiveRecord::Base
   validates :name, presence: true
   validates :topic, presence: true, inclusion: TOPICS.keys
 
+  serialize :events, RuleEventsSerializer
+
   accepts_nested_attributes_for :handlers, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :filters, allow_destroy: true, reject_if: :all_blank
 
   scope :enabled, -> { where(enabled: true) }
+
+  before_save :drop_old_events
+
+  private
+
+  def drop_old_events
+    self.events = self.events.last(EVENTS_TO_KEEP)
+  end
 end

--- a/app/models/rule_event.rb
+++ b/app/models/rule_event.rb
@@ -1,0 +1,29 @@
+class RuleEvent
+  def self.load(attributes)
+    object = allocate
+    object.instance_variable_set(:@timestamp, DateTime.parse(attributes.fetch("timestamp")))
+    object.instance_variable_set(:@details, attributes.fetch("details").map { RuleEventDetail.load(_1) })
+    object
+  end
+
+  def initialize
+    @timestamp = DateTime.now.utc
+    @details = []
+  end
+
+  attr_reader :timestamp, :details
+
+  def add_detail(level, message)
+    @details << RuleEventDetail.new(
+      level: level,
+      message: message,
+    )
+  end
+
+  def dump
+    {
+      "timestamp" => timestamp.to_s(:db),
+      "details" => details.map(&:dump),
+    }
+  end
+end

--- a/app/models/rule_event_detail.rb
+++ b/app/models/rule_event_detail.rb
@@ -1,0 +1,22 @@
+class RuleEventDetail
+  def self.load(attributes)
+    object = allocate
+    object.instance_variable_set(:@level, attributes.fetch('level').to_sym)
+    object.instance_variable_set(:@message, attributes.fetch("message"))
+    object
+  end
+
+  def initialize(level:, message:)
+    @level = level
+    @message = message
+  end
+
+  attr_reader :level, :message
+
+  def dump
+    {
+      "level" => level.to_s,
+      "message" => message,
+    }
+  end
+end

--- a/db/migrate/20220226134505_add_events_to_rules.rb
+++ b/db/migrate/20220226134505_add_events_to_rules.rb
@@ -1,0 +1,5 @@
+class AddEventsToRules < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rules, :events, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_11_205713) do
+ActiveRecord::Schema.define(version: 2022_02_26_134505) do
 
   create_table "filters", force: :cascade do |t|
     t.integer "rule_id", null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2022_02_11_205713) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "handle_count", default: 0, null: false
+    t.text "events"
     t.index ["rule_id"], name: "index_handlers_on_rule_id"
   end
 
@@ -39,6 +40,7 @@ ActiveRecord::Schema.define(version: 2022_02_11_205713) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "enabled", default: true, null: false
+    t.text "events"
     t.index ["shop_id"], name: "index_rules_on_shop_id"
   end
 

--- a/lib/rule_events_serializer.rb
+++ b/lib/rule_events_serializer.rb
@@ -1,0 +1,17 @@
+class RuleEventsSerializer
+  class << self
+    def dump(array)
+      data = array.map { |object| object.dump }
+      data.to_json
+    end
+
+    def load(string)
+      return [] if string.nil?
+
+      array = JSON.parse(string)
+      array.map do |data|
+        RuleEvent.load(data)
+      end
+    end
+  end
+end

--- a/lib/rule_runner.rb
+++ b/lib/rule_runner.rb
@@ -1,0 +1,58 @@
+class RuleRunner
+  def initialize(rule:, callback:)
+    @rule = rule
+    @callback = callback
+  end
+
+  def perform
+    rule_event.add_detail(:info, "Event received")
+
+    rule.filters.each.with_index do |filter, index|
+      valid = FilterValidator.new(filter).valid?(callback)
+      
+      if valid
+        rule_event.add_detail(:info, "Filter ##{index + 1}: Met")
+      else
+        rule_event.add_detail(:info, "Filter ##{index + 1}: Unmet, event dropped")
+
+        save_rule_event!
+        return
+      end
+    end
+
+    rule.handlers.each.with_index do |handler, index|
+      handle(handler, index)
+    end
+
+    save_rule_event!
+  end
+
+  private
+
+  attr_reader :rule, :callback
+
+  def rule_event
+    @rule_event ||= RuleEvent.new
+  end
+
+  def handle(handler, index)
+    handler.handle(callback)
+
+    rule_event.add_detail(:info, "Handler ##{index + 1}: Successful")
+  rescue Handlers::UserError => e
+    Rails.logger.info("User error: #{e.message}")
+
+    rule_event.add_detail(:error, "Handler ##{index + 1}: #{e.message}")
+  rescue StandardError
+    rule_event.add_detail(:error, "Handler ##{index + 1}: Server error")
+
+    save_rule_event!
+
+    raise
+  end
+
+  def save_rule_event!
+    rule.events = rule.events.push(rule_event)
+    rule.save!
+  end
+end

--- a/test/jobs/callback_webhook_job_test.rb
+++ b/test/jobs/callback_webhook_job_test.rb
@@ -13,7 +13,12 @@ class CallbackWebhookJobTest < ActiveSupport::TestCase
       "country" => "Canada",
     }
 
-    Handlers::Emailer.any_instance.expects(:call)
+    mock_runner = mock
+    mock_runner.expects(:perform)
+    RuleRunner
+      .expects(:new)
+      .with(rule: @shop.rules.first, callback: callback)
+      .returns(mock_runner)
 
     @job.perform(
       shop_domain: @shop.shopify_domain,

--- a/test/lib/rule_events_serializer_test.rb
+++ b/test/lib/rule_events_serializer_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class RuleEventsSerializerTest < ActiveSupport::TestCase
+  test '.dump' do
+    events = []
+    travel_to("2022-02-26 11:11:11 UTC") do
+      event = RuleEvent.new
+      event.add_detail(:info, "test 1")
+      events << event
+    end
+    travel_to("2022-02-26 22:22:22 UTC") do
+      event = RuleEvent.new
+      event.add_detail(:error, "test 2")
+      events << event
+    end
+
+    expected = "[" + \
+      "{\"timestamp\":\"2022-02-26 11:11:11\",\"details\":[{\"level\":\"info\",\"message\":\"test 1\"}]}," + \
+      "{\"timestamp\":\"2022-02-26 22:22:22\",\"details\":[{\"level\":\"error\",\"message\":\"test 2\"}]}" + \
+      "]"
+    assert_equal(expected, RuleEventsSerializer.dump(events))
+  end
+
+  test '.load' do
+    string = "[" + \
+      "{\"timestamp\":\"2022-02-26 11:11:11\",\"details\":[{\"level\":\"info\",\"message\":\"test 1\"}]}," + \
+      "{\"timestamp\":\"2022-02-26 22:22:22\",\"details\":[{\"level\":\"error\",\"message\":\"test 2\"}]}" + \
+      "]"
+
+    events = RuleEventsSerializer.load(string)
+
+    assert_equal(2, events.length)
+
+    assert_equal(DateTime.parse("2022-02-26 11:11:11"), events[0].timestamp)
+    assert_equal(1, events[0].details.length)
+    assert_equal(:info, events[0].details[0].level)
+    assert_equal("test 1", events[0].details[0].message)
+
+    assert_equal(DateTime.parse("2022-02-26 22:22:22"), events[1].timestamp)
+    assert_equal(1, events[1].details.length)
+    assert_equal(:error, events[1].details[0].level)
+    assert_equal("test 2", events[1].details[0].message)
+  end
+end

--- a/test/lib/rule_runner_test.rb
+++ b/test/lib/rule_runner_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class RuleRunnerTest < ActiveSupport::TestCase
+  setup do
+    @rule = rules(:email)
+    @runner = RuleRunner.new(
+      rule: @rule,
+      callback: {
+        "id" => "1234",
+        "email" => "test@example.com",
+        "country" => "Canada",
+      }
+    )
+  end
+
+  test '#perform' do
+    Handlers::Emailer.any_instance.expects(:call)
+
+    @runner.perform
+  end
+
+  test '#perform writes a rule event' do
+    Handlers::Emailer.any_instance.expects(:call)
+
+    assert_difference(-> { @rule.reload.events.length }, 1) do
+      travel_to("2022-02-26 18:33:03 UTC") do
+        @runner.perform
+      end
+    end
+
+    expected = {
+      "timestamp"=>"2022-02-26 18:33:03",
+      "details" => [
+        { "level" => "info", "message" => "Event received" },
+        { "level" => "info", "message" => "Filter #1: Met" },
+        { "level" => "info", "message" => "Handler #1: Successful" }
+      ]
+    }
+    assert_equal(expected, @rule.events.last.dump)
+  end
+
+  test '#perform on user error writes a rule event' do
+    Handlers::Emailer
+      .any_instance
+      .expects(:call)
+      .raises(Handlers::UserError, "Something wrong with Twillio")
+
+    assert_difference(-> { @rule.reload.events.length }, 1) do
+      travel_to("2022-02-26 18:33:03 UTC") do
+        @runner.perform
+      end
+    end
+
+    expected = {
+      "timestamp"=>"2022-02-26 18:33:03",
+      "details" => [
+        { "level" => "info", "message" => "Event received" },
+        { "level" => "info", "message" => "Filter #1: Met" },
+        { "level" => "error", "message" => "Handler #1: Something wrong with Twillio" }
+      ],
+    }
+    assert_equal(expected, @rule.events.last.dump)
+  end
+
+  test '#perform on server error writes a rule event' do
+    Handlers::Emailer
+      .any_instance
+      .expects(:call)
+      .raises(StandardError, "Some ruby unexpected behaviour")
+
+    assert_difference(-> { @rule.reload.events.length }, 1) do
+      travel_to("2022-02-26 18:33:03 UTC") do
+        assert_raises(StandardError) do
+          @runner.perform
+        end
+      end
+    end
+
+    expected = {
+      "timestamp"=>"2022-02-26 18:33:03",
+      "details" => [
+        { "level" => "info", "message" => "Event received" },
+        { "level" => "info", "message" => "Filter #1: Met" },
+        { "level" => "error", "message" => "Handler #1: Server error" }
+      ],
+    }
+    assert_equal(expected, @rule.events.last.dump)
+  end
+end

--- a/test/lib/rule_runner_test.rb
+++ b/test/lib/rule_runner_test.rb
@@ -36,7 +36,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
         { "level" => "info", "message" => "Handler #1: Successful" }
       ]
     }
-    assert_equal(expected, @rule.events.last.dump)
+    assert_equal(expected, @rule.reload.events.last.dump)
   end
 
   test '#perform on user error writes a rule event' do
@@ -59,7 +59,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
         { "level" => "error", "message" => "Handler #1: Something wrong with Twillio" }
       ],
     }
-    assert_equal(expected, @rule.events.last.dump)
+    assert_equal(expected, @rule.reload.events.last.dump)
   end
 
   test '#perform on server error writes a rule event' do
@@ -81,9 +81,9 @@ class RuleRunnerTest < ActiveSupport::TestCase
       "details" => [
         { "level" => "info", "message" => "Event received" },
         { "level" => "info", "message" => "Filter #1: Met" },
-        { "level" => "error", "message" => "Handler #1: Server error" }
+        { "level" => "error", "message" => "Server error" }
       ],
     }
-    assert_equal(expected, @rule.events.last.dump)
+    assert_equal(expected, @rule.reload.events.last.dump)
   end
 end

--- a/test/models/handler_test.rb
+++ b/test/models/handler_test.rb
@@ -13,14 +13,6 @@ class HandlerTest < ActiveSupport::TestCase
     end
   end
 
-  test "#handle increment handle_count on user error" do
-    Handlers::Emailer.any_instance.expects(:call).raises(Handlers::UserError)
-
-    assert_difference(-> { @handler.reload.handle_count }, 1) do
-      @handler.handle({})
-    end
-  end
-
   test "#handle increment handle_count on exceptions" do
     Handlers::Emailer.any_instance.expects(:call).raises(StandardError)
 

--- a/test/models/rule_event_detail_test.rb
+++ b/test/models/rule_event_detail_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class RuleEventDetailTest < ActiveSupport::TestCase
+  test ".load" do
+    attributes = {
+      "level" => "info",
+      "message" => "Test message",
+    }
+    detail = RuleEventDetail.load(attributes)
+
+    assert_equal(:info, detail.level)
+    assert_equal("Test message", detail.message)
+  end
+
+  test "#new" do
+    detail = RuleEventDetail.new(level: :info, message: "Test message")
+
+    assert_equal(:info, detail.level)
+    assert_equal("Test message", detail.message)
+  end
+
+  test "#dump" do
+    detail = RuleEventDetail.new(level: :info, message: "Test message")
+
+    expected = {
+      "level" => "info",
+      "message" => "Test message",
+    }
+    assert_equal(expected, detail.dump)
+  end
+end 

--- a/test/models/rule_event_test.rb
+++ b/test/models/rule_event_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class RuleEventTest < ActiveSupport::TestCase
+  test ".load" do
+    attributes = {
+      "timestamp" => "2022-02-26 18:33:03",
+      "details" => [
+        { "level" => "info", "message" => "Test message" },
+      ]
+    }
+    event = RuleEvent.load(attributes)
+
+    assert_equal(DateTime.parse("2022-02-26 18:33:03 UTC"), event.timestamp)
+    assert_equal(:info, event.details.first.level)
+    assert_equal("Test message", event.details.first.message)
+  end
+
+  test "#new" do
+    travel_to("2022-02-26 18:33:03 UTC") do
+      event = RuleEvent.new
+
+      assert_equal([], event.details)
+      assert_equal(DateTime.parse("2022-02-26 18:33:03 UTC"), event.timestamp)
+    end
+  end
+
+  test "#add_detail" do
+    event = RuleEvent.new
+    event.add_detail(:info, "Test message 1")
+    event.add_detail(:error, "Test message 2")
+
+    assert_equal(:info, event.details[0].level)
+    assert_equal("Test message 1", event.details[0].message)
+
+    assert_equal(:error, event.details[1].level)
+    assert_equal("Test message 2", event.details[1].message)
+  end
+
+  test "#dump" do
+    travel_to("2022-02-26 18:33:03 UTC") do
+      event = RuleEvent.new
+      event.add_detail(:info, "Test message")
+  
+      expected = {
+        "timestamp" => "2022-02-26 18:33:03",
+        "details" => [
+          { "level" => "info", "message" => "Test message" },
+        ]
+      }
+      assert_equal(expected, event.dump)
+    end
+  end
+end 

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -14,4 +14,54 @@ class RuleTest < ActiveSupport::TestCase
       topic: 'customers/create',
     )
   end
+
+  test "#events are persisted" do
+    assert_difference(-> { @rule.reload.events.length }, 1) do
+      travel_to("2022-02-26 18:33:03 UTC") do
+        event = RuleEvent.new
+        event.add_detail(:info, "test")
+
+        @rule.events = @rule.events.push(event)
+        @rule.save!
+      end
+    end
+
+    expected = DateTime.parse("2022-02-26T18:33:03.000Z")
+    assert_equal(expected, @rule.events.last.timestamp)
+  end
+
+  test "#events are persisted to a maximum of the last 10" do
+    10.times do
+      event = RuleEvent.new
+      event.add_detail(:info, "test")
+      @rule.events = @rule.events.push(event)
+    end
+    @rule.save!
+
+    assert_difference(-> { @rule.reload.events.length }, 0) do
+      travel_to("2022-02-26 18:33:03 UTC") do
+        event = RuleEvent.new
+        event.add_detail(:info, "test")
+
+        @rule.events = @rule.events.push(event)
+        @rule.save!
+      end
+    end
+
+    expected = DateTime.parse("2022-02-26T18:33:03.000Z")
+    assert_equal(expected, @rule.events.last.timestamp)
+  end
+
+  test "#event serialization persist non-ruby objects" do
+    travel_to("2022-02-26 18:33:03 UTC") do
+      event = RuleEvent.new
+      event.add_detail(:info, "test")
+      @rule.events = @rule.events.push(event)
+      @rule.save!
+    end
+
+    results = Rule.connection.select_all("SELECT events FROM rules")
+    expected = "[{\"timestamp\":\"2022-02-26 18:33:03\",\"details\":[{\"level\":\"info\",\"message\":\"test\"}]}]"
+    assert_equal(expected, results.rows.first.first)
+  end
 end


### PR DESCRIPTION
Alternative take on #85 and #106

Add support to retain "last rule events" for on every webhooks being processed. No views yet, only data models.

Quite a lot of code in here, some to be shipped in pre-PRs.

This PR add quite a big amount of custom serialization logic. Two reasons:
- Persistance wise: Opitimizing for number of mysql rows as opposed to a rich relational model. This is an operational constraint.
- Verbosity of code: I really want to avoid any ruby primitives in SQL. That being said, Rails does not seems to provide any rich mechanism to keep plain persistance while offering rich business logic without going all out custom serializer. 