### PR TITLE
Fix UI bug

### DIFF
--- a/app/javascript/packs/rules.js
+++ b/app/javascript/packs/rules.js
@@ -49,7 +49,7 @@ document.addEventListener("turbolinks:load", function (event) {
       return x.replace(/(\d+)/, new_id)
     }));
 
-    $clone.find('input[type="hidden"]').attr('value', 0);
+    $clone.find('[data-destroy-input]').attr('value', 0);
 
     $clone.appendTo("[data-" + target + "-list]");
 
@@ -60,7 +60,7 @@ document.addEventListener("turbolinks:load", function (event) {
     event.preventDefault();
 
     var parent = $(event.target).closest("[data-section]");
-    parent.hide().find('input[type="hidden"]').attr('value', 1);
+    parent.hide().find('[data-destroy-input]').attr('value', 1);
   });
 
   $('select').trigger('change');

--- a/app/views/rules/_filter.html.erb
+++ b/app/views/rules/_filter.html.erb
@@ -1,28 +1,26 @@
-<div class="Polaris-Card" data-section>  
-  <div class="Polaris-Card__Section">
-    <div class="Polaris-Card__SectionHeader">
-      <div class="Polaris-Stack Polaris-Stack--alignmentBaseline">
-        <div class="Polaris-Stack__Item Polaris-Stack__Item--fill"></div>
-        <div class="Polaris-Stack__Item">
-          <div class="Polaris-ButtonGroup">
-            <div class="Polaris-ButtonGroup__Item Polaris-ButtonGroup__Item--plain">
-              <button class="Polaris-Button Polaris-Button--destructive Polaris-Button--plain" type="button" data-destroy>
-                <span class="Polaris-Button__Content">
-                  <span class="Polaris-Button__Text">Remove</span>
-                </span>
-              </button>
-            </div>
+<div class="Polaris-Card__Section">
+  <div class="Polaris-Card__SectionHeader">
+    <div class="Polaris-Stack Polaris-Stack--alignmentBaseline">
+      <div class="Polaris-Stack__Item Polaris-Stack__Item--fill"></div>
+      <div class="Polaris-Stack__Item">
+        <div class="Polaris-ButtonGroup">
+          <div class="Polaris-ButtonGroup__Item Polaris-ButtonGroup__Item--plain">
+            <button class="Polaris-Button Polaris-Button--destructive Polaris-Button--plain" type="button" data-destroy>
+              <span class="Polaris-Button__Content">
+                <span class="Polaris-Button__Text">Remove</span>
+              </span>
+            </button>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <%= f.hidden_field :_destroy, value: local_assigns.fetch(:destroyed, false) %>
-    
-    <div class="Polaris-FormLayout">
-      <%= f.polaris_text_field(:value, placeholder: "line_items[*].vendor") %>
-      <%= f.polaris_select(:verb, Filter::VERBS.map { |k,v| [v, k] }, { prompt: 'Select a verb' }) %>
-      <%= f.polaris_text_field(:regex, placeholder: "Shopify") %>
-    </div>
+  <%= f.hidden_field :_destroy, value: local_assigns.fetch(:destroyed, false), data: { :'destroy-input' => true } %>
+
+  <div class="Polaris-FormLayout">
+    <%= f.polaris_text_field(:value, placeholder: "line_items[*].vendor") %>
+    <%= f.polaris_select(:verb, Filter::VERBS.map { |k,v| [v, k] }, { prompt: 'Select a verb' }) %>
+    <%= f.polaris_text_field(:regex, placeholder: "Shopify") %>
   </div>
 </div>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -53,16 +53,20 @@
         <div class="Polaris-Layout__AnnotationContent">
           <div data-filter-list>
             <% @rule.filters.each do |filter| %>
-              <%= f.fields_for :filters, filter do |ff| %>
-                <%= render 'filter', f: ff %>
-              <% end %>
+              <div class="Polaris-Card" data-section>
+                <%= f.fields_for :filters, filter do |ff| %>
+                  <%= render 'filter', f: ff %>
+                <% end %>
+              </div>
             <% end %>
           </div>
 
           <div style="display: none;" data-filter-template>
-            <%= f.fields_for :filters, Filter.new do |ff| %>
-              <%= render 'filter', f: ff, destroyed: true %>
-            <% end %>
+            <div class="Polaris-Card" data-section>
+              <%= f.fields_for :filters, Filter.new do |ff| %>
+                <%= render 'filter', f: ff, destroyed: true %>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>
@@ -92,16 +96,20 @@
         <div class="Polaris-Layout__AnnotationContent">
           <div data-handler-list>
             <% @rule.handlers.each do |handler| %>
-              <%= f.fields_for :handlers, handler do |ff| %>
-                <%= render 'handler', f: ff %>
-              <% end %>
+              <div class="Polaris-Card" data-section>
+                <%= f.fields_for :handlers, handler do |ff| %>
+                  <%= render 'handler', f: ff %>
+                <% end %>
+              </div>
             <% end %>
           </div>
 
           <div style="display: none;" data-handler-template>
-            <%= f.fields_for :handlers, Handler.new do |ff| %>
-              <%= render 'handler', f: ff, destroyed: true %>
-            <% end %>
+            <div class="Polaris-Card" data-section>
+              <%= f.fields_for :handlers, Handler.new do |ff| %>
+                <%= render 'handler', f: ff, destroyed: true %>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/rules/_handler.html.erb
+++ b/app/views/rules/_handler.html.erb
@@ -1,49 +1,47 @@
-<div class="Polaris-Card" data-section>  
-  <div class="Polaris-Card__Section">
-    <div class="Polaris-Card__SectionHeader">
-      <div class="Polaris-Stack Polaris-Stack--alignmentBaseline">
-        <div class="Polaris-Stack__Item Polaris-Stack__Item--fill"></div>
-        <div class="Polaris-Stack__Item">
-          <div class="Polaris-ButtonGroup">
-            <div class="Polaris-ButtonGroup__Item Polaris-ButtonGroup__Item--plain">
-              <button class="Polaris-Button Polaris-Button--destructive Polaris-Button--plain" type="button" data-destroy>
-                <span class="Polaris-Button__Content">
-                  <span class="Polaris-Button__Text">Remove</span>
-                </span>
-              </button>
-            </div>
+<div class="Polaris-Card__Section">
+  <div class="Polaris-Card__SectionHeader">
+    <div class="Polaris-Stack Polaris-Stack--alignmentBaseline">
+      <div class="Polaris-Stack__Item Polaris-Stack__Item--fill"></div>
+      <div class="Polaris-Stack__Item">
+        <div class="Polaris-ButtonGroup">
+          <div class="Polaris-ButtonGroup__Item Polaris-ButtonGroup__Item--plain">
+            <button class="Polaris-Button Polaris-Button--destructive Polaris-Button--plain" type="button" data-destroy>
+              <span class="Polaris-Button__Content">
+                <span class="Polaris-Button__Text">Remove</span>
+              </span>
+            </button>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <%= f.hidden_field :_destroy, value: local_assigns.fetch(:destroyed, false) %>
+  <%= f.hidden_field :_destroy, value: local_assigns.fetch(:destroyed, false), data: { :'destroy-input' => true } %>
 
-    <div class="Polaris-FormLayout">
-      <%= f.polaris_select(:service_name, available_handlers.map { |handler| [handler.label, handler.to_s] }, { prompt: "Select an action" }, { data: { handler: true } }) %>
+  <div class="Polaris-FormLayout">
+    <%= f.polaris_select(:service_name, available_handlers.map { |handler| [handler.label, handler.to_s] }, { prompt: "Select an action" }, { data: { handler: true } }) %>
 
-      <%= f.fields_for :settings, f.object.settings do |ff| %>
-        <% available_handlers.each do |handler| %>
-          <div data-handler-details="<%= handler %>">
-            <% if handler.description.present? %>
-              <div class="Polaris-FormLayout__Item">
-                <p class="Polaris-TextStyle--variationSubdued"><%= raw(handler.description) %></p>
-              </div>
+    <%= f.fields_for :settings, f.object.settings do |ff| %>
+      <% available_handlers.each do |handler| %>
+        <div data-handler-details="<%= handler %>">
+          <% if handler.description.present? %>
+            <div class="Polaris-FormLayout__Item">
+              <p class="Polaris-TextStyle--variationSubdued"><%= raw(handler.description) %></p>
+            </div>
+          <% end %>
+
+          <% handler.settings.each do |name, options| %>
+            <% label = options[:optional] ? "#{options[:name]} <i>(optional)</i>" : options[:name] %>
+            <% help = "<b>Example:</b> #{options[:example]}" if options.key?(:example) %>
+
+            <% if options.key?(:options) %>
+              <%= ff.polaris_select(name, options[:options], { help: help, selected: f.object.settings[name] }) %>
+            <% else %>
+              <%= ff.polaris_text_field(name, help: help, value: f.object.settings[name]) %>
             <% end %>
-
-            <% handler.settings.each do |name, options| %>
-              <% label = options[:optional] ? "#{options[:name]} <i>(optional)</i>" : options[:name] %>
-              <% help = "<b>Example:</b> #{options[:example]}" if options.key?(:example) %>
-
-              <% if options.key?(:options) %>
-                <%= ff.polaris_select(name, options[:options], { help: help, selected: f.object.settings[name] }) %>
-              <% else %>
-                <%= ff.polaris_text_field(name, help: help, value: f.object.settings[name]) %>
-              <% end %>
-            <% end %>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
       <% end %>
-    </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
Fixes a bug where Polaris cards would stick to each other when they should definitely be separated.

<img width="951" alt="Screen Shot 2022-03-01 at 10 27 48 PM" src="https://user-images.githubusercontent.com/596120/156291594-f0cccc32-95aa-4285-8cca-f5e1ce5b9fa1.png">

The problem stems from a mix between `fields_for` and Polaris. For cards to be separated, Polaris expects them to be next to each other in the DOM, with this CSS snippet. The `+` sign here meaning adjacent siblings.

<img width="358" alt="Screen Shot 2022-03-01 at 10 28 59 PM" src="https://user-images.githubusercontent.com/596120/156291657-699971f0-7181-413e-a271-add6d0178474.png">

Unfortunately, when using `fields_for` in Rails, it injects a hidden `id` field at the very end of the block, which means that if we do;

```ruby
3.times do
  form.fields_for :foo, :bar do
    <Polaris.Card>
  end
end
```

We'll actually end up with;

```html
<Card>
<input type="hidden" name="id" value="1">
<Card>
<input type="hidden" name="id" value="2">
<Card>
<input type="hidden" name="id" value="3">
```

Meaning the CSS selector won't kick in. With this PR, I'm tweaking the way we generate the fields as to extract the Polaris card out of it, so that the inserted ID doesn't mess things up. There probably would have been a better way, but it's late...

Best reviewed with [w=1](https://github.com/christianblais/triggerify/pull/120/files?w=1).