### PR TITLE
From serializer to attribute

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -53,7 +53,7 @@ class Rule < ActiveRecord::Base
   validates :name, presence: true
   validates :topic, presence: true, inclusion: TOPICS.keys
 
-  serialize :events, RuleEventRepository
+  attribute :events, RuleEventRepositoryType.new
 
   accepts_nested_attributes_for :handlers, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :filters, allow_destroy: true, reject_if: :all_blank

--- a/app/models/rule_event_repository.rb
+++ b/app/models/rule_event_repository.rb
@@ -5,8 +5,6 @@ class RuleEventRepository
     end
 
     def load(data)
-      return new if data.nil?
-
       object = allocate
       object.instance_variable_set(:@events, data.map { RuleEvent.load(_1) })
       object

--- a/lib/rule_event_repository_type.rb
+++ b/lib/rule_event_repository_type.rb
@@ -1,0 +1,17 @@
+class RuleEventRepositoryType < ActiveModel::Type::Value
+  def type
+    :json
+  end
+
+  def cast_value(value)
+    RuleEventRepository.load(ActiveSupport::JSON.decode(value))
+  end
+
+  def serialize(value)
+    ActiveSupport::JSON.encode(value.dump)
+  end
+
+  def changed_in_place?(raw_old_value, new_value)
+    cast_value(raw_old_value) != new_value
+  end
+end


### PR DESCRIPTION
This is what would be required to get rid of the `return if nil`. Also IMO less magical, aka we're in control of the methods being called. This would allow us to get rid of the dump/load in favor of a more regular `as_json` approach? Anyway, food for thoughts, I don't mind either way.

/cc @tjoyal 