### PR TITLE
Add event identifier

### DIFF
--- a/app/controllers/callback_controller.rb
+++ b/app/controllers/callback_controller.rb
@@ -1,24 +1,12 @@
 class CallbackController < ApplicationController
   include ShopifyApp::WebhookVerification
 
-  def webhook
-    CallbackWebhookJob.perform_later(
-      shop_domain: shop.shopify_domain,
-      callback: params[:callback].to_unsafe_h,
-      topic: params[:topic]
-    )
-
-    head :ok
-  rescue => e
-    Bugsnag.notify(e)
-    head :ok
-  end
-
   def receive
     CallbackWebhookJob.perform_later(
       shop_domain: request.headers.fetch('X-Shopify-Shop-Domain'),
       callback: params.fetch(:callback).to_unsafe_h,
-      topic: request.headers.fetch('X-Shopify-Topic')
+      topic: request.headers.fetch('X-Shopify-Topic'),
+      shopify_identifier: request.headers.fetch('X-Shopify-Webhook-Id')
     )
 
     head :ok

--- a/app/jobs/callback_webhook_job.rb
+++ b/app/jobs/callback_webhook_job.rb
@@ -1,18 +1,19 @@
 class CallbackWebhookJob < ShopJob
-  def perform_with_shop(topic:, callback:)
+  def perform_with_shop(topic:, callback:, shopify_identifier:)
     rules = shop.rules.enabled.where(topic: topic)
 
     rules.each do |rule|
-      process_rule(rule, callback)
+      process_rule(rule, callback, shopify_identifier)
     end
   end
 
   private
 
-  def process_rule(rule, callback)
+  def process_rule(rule, callback, shopify_identifier)
     RuleRunner.new(
       rule: rule,
-      callback: callback
+      callback: callback,
+      shopify_identifier: shopify_identifier
     ).perform
   rescue StandardError => e
     report_exception(e) do |report|

--- a/app/models/rule_event.rb
+++ b/app/models/rule_event.rb
@@ -1,15 +1,17 @@
 class RuleEvent
   def self.load(attributes)
     object = allocate
+    object.instance_variable_set(:@identifier, attributes.fetch("identifier", ""))
     object.instance_variable_set(:@details, attributes.fetch("details").map { RuleEventDetail.load(_1) })
     object
   end
 
-  def initialize
+  def initialize(identifier:)
+    @identifier = identifier
     @details = []
   end
 
-  attr_reader :details
+  attr_reader :details, :identifier
 
   def add_detail(level, message)
     @details << RuleEventDetail.new(
@@ -20,13 +22,14 @@ class RuleEvent
 
   def dump
     {
+      "identifier" => @identifier,
       "details" => @details.map(&:dump),
     }
   end
 
   def as_json
     dump.merge({
-      name: @details.first.timestamp.to_s(:db),
+      name: @identifier,
       error: @details.any? { _1.level == :error },
     })
   end

--- a/app/models/rule_event.rb
+++ b/app/models/rule_event.rb
@@ -1,6 +1,7 @@
 class RuleEvent
   def self.load(attributes)
     object = allocate
+    # Ensures we do not bust on historic events that do not have an identifier
     object.instance_variable_set(:@identifier, attributes.fetch("identifier", ""))
     object.instance_variable_set(:@details, attributes.fetch("details").map { RuleEventDetail.load(_1) })
     object

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # OLD
-  post '/webhooks/rules/:shop_id/:topic', to: 'callback#webhook', constraints: { shop_id: /\d+/, topic: /.*/ }
-
-  # NEW
   post '/webhooks/receive', to: 'callback#receive'
 
   root to: 'home#index'

--- a/lib/rule_runner.rb
+++ b/lib/rule_runner.rb
@@ -1,7 +1,8 @@
 class RuleRunner
-  def initialize(rule:, callback:)
+  def initialize(rule:, callback:, shopify_identifier:)
     @rule = rule
     @callback = callback
+    @shopify_identifier = shopify_identifier
   end
 
   def perform
@@ -35,10 +36,10 @@ class RuleRunner
 
   private
 
-  attr_reader :rule, :callback
+  attr_reader :rule, :callback, :shopify_identifier
 
   def rule_event
-    @rule_event ||= RuleEvent.new
+    @rule_event ||= RuleEvent.new(identifier: shopify_identifier)
   end
 
   def handle(handler, index)

--- a/test/jobs/callback_webhook_job_test.rb
+++ b/test/jobs/callback_webhook_job_test.rb
@@ -17,13 +17,14 @@ class CallbackWebhookJobTest < ActiveSupport::TestCase
     mock_runner.expects(:perform)
     RuleRunner
       .expects(:new)
-      .with(rule: @shop.rules.first, callback: callback)
+      .with(rule: @shop.rules.first, callback: callback, shopify_identifier: 'abc')
       .returns(mock_runner)
 
     @job.perform(
       shop_domain: @shop.shopify_domain,
       topic: "customers/create",
       callback: callback,
+      shopify_identifier: 'abc',
     )
   end
 end

--- a/test/lib/rule_runner_test.rb
+++ b/test/lib/rule_runner_test.rb
@@ -9,7 +9,8 @@ class RuleRunnerTest < ActiveSupport::TestCase
         "id" => "1234",
         "email" => "test@example.com",
         "country" => "Canada",
-      }
+      },
+      shopify_identifier: 'abc'
     )
   end
 
@@ -29,6 +30,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
     end
 
     expected = {
+      "identifier" => "abc",
       "details" => [
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Event received" },
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Filter #1: Met" },
@@ -46,7 +48,8 @@ class RuleRunnerTest < ActiveSupport::TestCase
       callback: {
         "id" => "1234",
         "country" => "Not-Canada",
-      }
+      },
+      shopify_identifier: "abc"
     )
 
     assert_difference(-> { @rule.reload.events.count }, 1) do
@@ -56,6 +59,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
     end
 
     expected = {
+      "identifier" => "abc",
       "details" => [
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Event received" },
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Filter #1: Unmet" },
@@ -78,6 +82,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
     end
 
     expected = {
+      "identifier" => "abc",
       "details" => [
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Event received" },
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Filter #1: Met" },
@@ -102,6 +107,7 @@ class RuleRunnerTest < ActiveSupport::TestCase
     end
 
     expected = {
+      "identifier" => "abc",
       "details" => [
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Event received" },
         { "timestamp"=>"2022-02-26 18:33:03", "level" => "info", "message" => "Filter #1: Met" },

--- a/test/models/rule_event_repository_test.rb
+++ b/test/models/rule_event_repository_test.rb
@@ -7,49 +7,58 @@ class RuleEventRepositoryTest < ActiveSupport::TestCase
 
   test '.dump' do
     travel_to("2022-02-26 11:11:11 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'abc')
       event.add_detail(:info, "test 1")
       @repository.add_event(event)
     end
     travel_to("2022-02-26 22:22:22 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'xyz')
       event.add_detail(:error, "test 2")
       @repository.add_event(event)
     end
 
     expected = [
-      { "details" => [{ "timestamp"=>"2022-02-26 11:11:11", "level"=>"info", "message"=>"test 1" }]},
-      { "details" => [{ "timestamp"=>"2022-02-26 22:22:22", "level"=>"error", "message"=>"test 2" }]}
+      { "identifier" => "abc", "details" => [{ "timestamp"=>"2022-02-26 11:11:11", "level"=>"info", "message"=>"test 1" }]},
+      { "identifier" => "xyz", "details" => [{ "timestamp"=>"2022-02-26 22:22:22", "level"=>"error", "message"=>"test 2" }]}
     ]
     assert_equal(expected, RuleEventRepository.dump(@repository))
   end
 
   test '.load' do
     raw = [
-      { "details" => [{ "timestamp"=>"2022-02-26 11:11:11", "level"=>"info", "message"=>"test 1" }]},
-      { "details" => [{ "timestamp"=>"2022-02-26 22:22:22", "level"=>"error", "message"=>"test 2" }]}
+      { "identifier" => "abc", "details" => [{ "timestamp"=>"2022-02-26 11:11:11", "level"=>"info", "message"=>"test 1" }]},
+      { "identifier" => "xyz", "details" => [{ "timestamp"=>"2022-02-26 22:22:22", "level"=>"error", "message"=>"test 2" }]},
+      { "details" => []}
     ]
 
     repository = RuleEventRepository.load(raw)
 
-    assert_equal(2, repository.count)
+    assert_equal(3, repository.count)
 
     first_event = repository.to_a[0]
+    assert_equal("abc", first_event.identifier)
     assert_equal(1, first_event.details.count)
     assert_equal(DateTime.parse("2022-02-26 11:11:11"), first_event.details[0].timestamp)
     assert_equal(:info, first_event.details[0].level)
     assert_equal("test 1", first_event.details[0].message)
 
     second_event = repository.to_a[1]
+    assert_equal("xyz", second_event.identifier)
     assert_equal(1, second_event.details.count)
     assert_equal(DateTime.parse("2022-02-26 22:22:22"), second_event.details[0].timestamp)
     assert_equal(:error, second_event.details[0].level)
     assert_equal("test 2", second_event.details[0].message)
+
+    # temporary backfill as not all events have an identifier?
+    # todo: purge existing events, remove this feature?
+    third_event = repository.to_a[2]
+    assert_equal("", third_event.identifier)
+    assert_equal(0, third_event.details.count)
   end
 
   test "#add_event" do
     travel_to("2022-02-26 18:33:03 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: "abc")
       event.add_detail(:info, "test")
 
       @repository.add_event(event)
@@ -64,14 +73,14 @@ class RuleEventRepositoryTest < ActiveSupport::TestCase
 
   test "#add_event kept a maximum of the last 10" do
     10.times do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'abc')
       event.add_detail(:info, "test")
       @repository.add_event(event)
     end
 
     assert_equal(10, @repository.count)
 
-    extra_event = RuleEvent.new
+    extra_event = RuleEvent.new(identifier: 'xyz')
     extra_event.add_detail(:info, "test extra")
 
     assert_difference(-> { @repository.count }, 0) do

--- a/test/models/rule_event_test.rb
+++ b/test/models/rule_event_test.rb
@@ -3,12 +3,14 @@ require 'test_helper'
 class RuleEventTest < ActiveSupport::TestCase
   test ".load" do
     attributes = {
+      "identifier" => "abc",
       "details" => [
         { "timestamp" => "2022-02-26 18:33:03", "level" => "info", "message" => "Test message" },
       ]
     }
     event = RuleEvent.load(attributes)
 
+    assert_equal("abc", event.identifier)
     assert_equal(DateTime.parse("2022-02-26 18:33:03 UTC"), event.details.first.timestamp)
     assert_equal(:info, event.details.first.level)
     assert_equal("Test message", event.details.first.message)
@@ -16,7 +18,7 @@ class RuleEventTest < ActiveSupport::TestCase
 
   test "#add_detail" do
     travel_to("2022-02-26 18:33:03 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'abc')
       event.add_detail(:info, "Test message 1")
       event.add_detail(:error, "Test message 2")
 
@@ -32,10 +34,11 @@ class RuleEventTest < ActiveSupport::TestCase
 
   test "#dump" do
     travel_to("2022-02-26 18:33:03 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'abc')
       event.add_detail(:info, "Test message")
   
       expected = {
+        "identifier" => "abc",
         "details" => [
           { "timestamp" => "2022-02-26 18:33:03", "level" => "info", "message" => "Test message" },
         ]

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -16,7 +16,7 @@ class RuleTest < ActiveSupport::TestCase
   end
 
   test "#events are persisted" do
-    event = RuleEvent.new
+    event = RuleEvent.new(identifier: 'abc')
     event.add_detail(:info, "test persistence")
 
     assert_difference(-> { @rule.reload.events.count }, 1) do
@@ -29,14 +29,14 @@ class RuleTest < ActiveSupport::TestCase
 
   test "#event serialization persist non-ruby objects" do
     travel_to("2022-02-26 18:33:03 UTC") do
-      event = RuleEvent.new
+      event = RuleEvent.new(identifier: 'abc')
       event.add_detail(:info, "test")
       @rule.events.add_event(event)
       @rule.save!
     end
 
     results = Rule.connection.select_all("SELECT events FROM rules where id = #{@rule.id}")
-    expected = '[{"details":[{"timestamp":"2022-02-26 18:33:03","level":"info","message":"test"}]}]'
+    expected = '[{"identifier":"abc","details":[{"timestamp":"2022-02-26 18:33:03","level":"info","message":"test"}]}]'
     assert_equal(expected, results.rows.first.first)
   end
 


### PR DESCRIPTION
@tjoyal this is an attempt at sending a source/identifier down the hole. Name is identifier, although it isn't meant to be unique, i.e. Hooklys can send us the same webhook multiple times. Thoughts?