### PR TITLE
Tweak navigation

### DIFF
--- a/app/javascript/components/rules/index.js
+++ b/app/javascript/components/rules/index.js
@@ -26,6 +26,10 @@ class Index extends React.Component {
                     <Card.Section title={ rule.name }
                       actions={[
                         {
+                          content: 'Activity',
+                          url: `/rules/${ rule.id }/activity`
+                        },
+                        {
                           content: 'Edit',
                           url: `/rules/${ rule.id }`
                         },

--- a/app/views/rules/activity.html.erb
+++ b/app/views/rules/activity.html.erb
@@ -1,22 +1,25 @@
 <%= react_component("rules/activity", { events: @rule.events.as_json.reverse }) %>
 
 <script>
-  // App Bridge limits to a single breadcrumb...
   var breadcrumb = Button.create(app, { label: '<%= @rule.name %>' });
   breadcrumb.subscribe(Button.Action.CLICK, () => {
     Turbolinks.visit('<%= rule_path(@rule) %>');
   });
 
-  var button = Button.create(app, { label: 'Back' });
+  var button1 = Button.create(app, { label: 'Back' });
+  button1.subscribe('click', () => {
+    Turbolinks.visit('<%= rules_path %>');
+  });
 
-  button.subscribe('click', () => {
+  var button2 = Button.create(app, { label: 'Edit' });
+  button2.subscribe('click', () => {
     Turbolinks.visit('<%= rule_path(@rule) %>');
   });
 
   TitleBar.create(app, {
     title: 'Activity',
     buttons: {
-      secondary: [button]
+      secondary: [button1, button2]
     },
     breadcrumbs: breadcrumb
   });


### PR DESCRIPTION
Tweaking navigation to make it easier to reach the activity tab.

On Index;
- Adding a "Activity" link to cards

On Edit;
- Keeping the "Activity" link

On Activity;
- Adding a link to "Edit"

This becomes some sort of a three way route;

```
Index _____ Activity
      \        |
       \       |
        \      |
         \ __ Edit
```