### PR TITLE
Activity page UI

### DIFF
--- a/app/javascript/components/rules/activity.js
+++ b/app/javascript/components/rules/activity.js
@@ -1,54 +1,33 @@
 import React from "react"
-import { AppProvider, Layout, Card, Badge, Caption, TextContainer, Banner } from '@shopify/polaris'
+import { AppProvider, Layout, Card, Badge, DescriptionList, Caption } from '@shopify/polaris'
 
 class Activity extends React.Component {
   render () {
     return (
       <AppProvider>
         <Layout>
-          <Layout.AnnotatedSection
-            id="ruleActivity"
-            title="Activity"
-            description="See the most recent activity pertaining to this rule."
-          >
-            { this.props.events.map((event, i) => {
-              let banner;
+          { this.props.events.map((event, i) => {
+            let description = <p>
+              <b>Webhook ID</b><br /><Caption>{ event.identifier }</Caption>
+            </p>
 
-              if (event.error) {
-                banner =
-                  <Card.Section>
-                    <Banner status="warning">
-                      <p>There has been a problem executing this rule.</p>
-                    </Banner>
-                  </Card.Section>
-              }
+            return(
+              <Layout.AnnotatedSection id={ i } title={ event.timestamp } description={ description }>
+                <Card sectioned>
+                  <DescriptionList items={
+                    event.details.map((details, j) => {
+                      let badgeStatus = details.level == "info" ? "info" : "warning";
 
-              return(
-                <Card title={ event.name } key={ i }>
-                  { banner }
-
-                  { event.details.map((details, j) => {
-                    let badgeStatus = details.level == "info" ? "info" : "warning";
-
-                    return(
-                      <Card.Section key={ j }>
-                        <TextContainer>
-                          <p>
-                            <Badge status={ badgeStatus }>{ details.level }</Badge>
-                            &nbsp;
-                            { details.message }
-                          </p>
-                          <p>
-                            <Caption>{ details.timestamp }</Caption>
-                          </p>
-                        </TextContainer>
-                      </Card.Section>
-                    );
-                  }) }
+                      return({
+                        term: <Badge status={ badgeStatus }>{ details.level }</Badge>,
+                        description: details.message
+                      });
+                    })
+                  } />
                 </Card>
-              );
-            }) }
-          </Layout.AnnotatedSection>
+              </Layout.AnnotatedSection>
+            );
+          })}
         </Layout>
       </AppProvider>
     );

--- a/app/models/rule_event.rb
+++ b/app/models/rule_event.rb
@@ -30,7 +30,8 @@ class RuleEvent
 
   def as_json
     dump.merge({
-      name: @identifier,
+      identifier: @identifier,
+      timestamp: @details.first.timestamp.to_s(:db),
       error: @details.any? { _1.level == :error },
     })
   end


### PR DESCRIPTION
Few tweaks to how we display activities. Main idea;

- Use the left space for each events, as opposed to a page description
- Better distinguish between each event

Before;
<img width="1119" alt="Screen Shot 2022-03-07 at 1 51 53 PM" src="https://user-images.githubusercontent.com/596120/157098878-184af99b-1c89-479c-8d0e-b92cecd97924.png">

After;
<img width="1133" alt="Screen Shot 2022-03-07 at 1 50 31 PM" src="https://user-images.githubusercontent.com/596120/157098699-6020f921-4dad-4985-a7ae-564c4faf0e17.png">

