### PR TITLE
Rule index: Add activity insight

### DIFF
--- a/app/javascript/components/rules/index.js
+++ b/app/javascript/components/rules/index.js
@@ -1,67 +1,107 @@
 import React from "react"
 import { AppProvider, Layout, Card, Badge } from '@shopify/polaris'
 
+class Rule extends React.Component {
+  render () {
+    let rule = this.props.rule;
+
+    let status;
+    if (!rule.enabled) {
+      status = <Badge status="new">Disabled</Badge>;
+    }
+    else if (rule.events.length === 0) {
+      status = <Badge status="new">No activity</Badge>;
+    }
+    else if (rule.events.length > 0 && rule.events[rule.events.length - 1].error) {
+      status = <Badge status="warning">Warning</Badge>;
+    }
+    else {
+      status = <Badge status="success">Healthy</Badge>;
+    }
+
+    return (
+      <Card>
+        <Card.Section title={ rule.name }
+          actions={[
+            {
+              content: 'Activity',
+              url: `/rules/${ rule.id }/activity`
+            },
+            {
+              content: 'Edit',
+              url: `/rules/${ rule.id }`
+            },
+            {
+              content: 'Delete',
+              url: `/rules/${ rule.id }`,
+              onAction: (event) => {
+                if (event.currentTarget.getAttribute('data-remote'))
+                  return;
+
+                event.preventDefault();
+                event.stopPropagation();
+
+                if (window.confirm('Delete this rule?')) {
+                  event.currentTarget.setAttribute("data-remote", "remote");
+                  event.currentTarget.setAttribute("data-method", "delete");
+
+                  event.currentTarget.click();
+                }
+              }
+            }
+          ]}
+        >
+          <p>
+            { status }
+          </p>
+        </Card.Section>
+      </Card>
+    );
+  }
+}
+
 class Index extends React.Component {
   render () {
+    let rules_enabled = [];
+    let rules_disabled = [];
+    this.props.rules.forEach((rule) => {
+      rule.enabled ? rules_enabled.push(rule) : rules_disabled.push(rule)
+    });
+
+    let enabled_section = <Layout.AnnotatedSection
+      id="ruleIndex"
+      title="Enabled rules"
+      description="Rules are listening to events produced by your Shopify store."
+    >
+      {
+        rules_enabled.map(function(rule, index) {
+          return <Rule rule={ rule } key={ index } />
+        })
+      }
+    </Layout.AnnotatedSection>;
+
+    let disabled_section;
+    if (rules_disabled.length > 0) {
+      disabled_section =
+        <Layout.AnnotatedSection
+          id="ruleIndex"
+          title="Disabled rules"
+          description="Rules can be enabled from their edit section."
+        >
+          {
+            rules_disabled.map(function(rule, index) {
+              return <Rule rule={ rule } key={ index } />
+            })
+          }
+        </Layout.AnnotatedSection>
+    }
+ 
+
     return (
       <AppProvider>
         <Layout>
-          <Layout.AnnotatedSection
-            id="ruleIndex"
-            title="Rules"
-            description="These are the rules you created."
-          >
-            {
-              this.props.rules.map(function(rule, index) {
-                let badge;
-
-                if (rule.enabled) {
-                  badge = <Badge status="success">Enabled</Badge>
-                } else {
-                  badge = <Badge status="warning">Disabled</Badge>
-                }
-                
-                return (
-                  <Card key={ index }>
-                    <Card.Section title={ rule.name }
-                      actions={[
-                        {
-                          content: 'Activity',
-                          url: `/rules/${ rule.id }/activity`
-                        },
-                        {
-                          content: 'Edit',
-                          url: `/rules/${ rule.id }`
-                        },
-                        {
-                          content: 'Delete',
-                          url: `/rules/${ rule.id }`,
-                          onAction: (event) => {
-                            if (event.currentTarget.getAttribute('data-remote'))
-                              return;
-
-                            event.preventDefault();
-                            event.stopPropagation();
-
-                            if (window.confirm('Delete this rule?')) {
-                              event.currentTarget.setAttribute("data-remote", "remote");
-                              event.currentTarget.setAttribute("data-method", "delete");
-
-                              event.currentTarget.click();
-                            }
-                          }
-                        }
-                      ]}
-                    >
-                      <p>
-                        { badge }
-                      </p>
-                    </Card.Section>
-                  </Card>
-                );
-              })
-            }
-          </Layout.AnnotatedSection>
+          { enabled_section }
+          { disabled_section }
         </Layout>
       </AppProvider>
     );


### PR DESCRIPTION
I experimented with the index page, trying to expose some of the "last activity" in.

There is some more work I'd like to do (eg.: turn as a warning or some kind of flag when no event was received in the last 24h) but for now this seems to be a good start.

<img width="1550" alt="Screen Shot 2022-03-10 at 8 08 30 AM" src="https://user-images.githubusercontent.com/207902/157668496-7ba9d520-2377-40d1-96f5-deee0e895a75.png">
<img width="1552" alt="Screen Shot 2022-03-10 at 8 08 45 AM" src="https://user-images.githubusercontent.com/207902/157668497-3f174355-c1aa-43c1-aba5-c91d4afe72b5.png">
<img width="1552" alt="Screen Shot 2022-03-10 at 8 09 10 AM" src="https://user-images.githubusercontent.com/207902/157668499-f22fa97e-b170-405b-be21-b9c73fc25665.png">
