### PR TITLE
Fix taggable handler

### DIFF
--- a/app/controllers/callback_controller.rb
+++ b/app/controllers/callback_controller.rb
@@ -7,7 +7,7 @@ class CallbackController < ApplicationController
       callback: params.fetch(:callback).to_unsafe_h,
       topic: request.headers.fetch('X-Shopify-Topic'),
       shopify_identifier: request.headers.fetch('X-Shopify-Webhook-Id'),
-      hooklys_identifier: request.headers.fetch('X-Hooklys-Id')
+      hooklys_identifier: request.headers.fetch('X-Hooklys-Id', "")
     )
 
     head :ok

--- a/app/models/handler.rb
+++ b/app/models/handler.rb
@@ -22,7 +22,7 @@ class Handler < ActiveRecord::Base
   end
 
   def handle(payload)
-    instance = service.new(settings, payload)
+    instance = service.new(rule.shop, settings, payload)
 
     begin
       instance.call

--- a/lib/handlers/base.rb
+++ b/lib/handlers/base.rb
@@ -34,7 +34,8 @@ module Handlers
       end
     end
 
-    def initialize(settings, payload)
+    def initialize(shop, settings, payload)
+      @shop = shop
       @settings = settings
       @payload = payload
     end

--- a/test/lib/handlers/datadog_event_test.rb
+++ b/test/lib/handlers/datadog_event_test.rb
@@ -52,7 +52,8 @@ module Handlers
         priority: priority,
       }
 
-      DatadogEvent.new(settings, {})
+      shop = shops(:regular_shop)
+      DatadogEvent.new(shop, settings, {})
     end
   end
 end

--- a/test/lib/handlers/emailer_test.rb
+++ b/test/lib/handlers/emailer_test.rb
@@ -89,7 +89,8 @@ module Handlers
         body: body,
       }
 
-      Emailer.new(settings, {})
+      shop = shops(:regular_shop)
+      Emailer.new(shop, settings, {})
     end
   end
 end

--- a/test/lib/handlers/gift_card_test.rb
+++ b/test/lib/handlers/gift_card_test.rb
@@ -25,7 +25,8 @@ module Handlers
         customer_id: customer_id,
       }
 
-      GiftCard.new(settings, {})
+      shop = shops(:regular_shop)
+      GiftCard.new(shop, settings, {})
     end
   end
 end

--- a/test/lib/handlers/sendgrid_test.rb
+++ b/test/lib/handlers/sendgrid_test.rb
@@ -147,7 +147,8 @@ module Handlers
         body: body,
       }
 
-      SendGrid.new(settings, {})
+      shop = shops(:regular_shop)
+      SendGrid.new(shop, settings, {})
     end
   end
 end

--- a/test/lib/handlers/slack_test.rb
+++ b/test/lib/handlers/slack_test.rb
@@ -46,7 +46,8 @@ module Handlers
         message: message,
       }
 
-      Slack.new(settings, {})
+      shop = shops(:regular_shop)
+      Slack.new(shops, settings, {})
     end
   end
 end

--- a/test/lib/handlers/sms_test.rb
+++ b/test/lib/handlers/sms_test.rb
@@ -61,7 +61,8 @@ module Handlers
         message: message,
       }
 
-      SMS.new(settings, {})
+      shop = shops(:regular_shop)
+      SMS.new(shop, settings, {})
     end
   end
 end

--- a/test/lib/handlers/twitter_test.rb
+++ b/test/lib/handlers/twitter_test.rb
@@ -33,7 +33,8 @@ module Handlers
         message: message,
       }
 
-      Twitter.new(settings, {})
+      shop = shops(:regular_shop)
+      Twitter.new(shop, settings, {})
     end
   end
 end


### PR DESCRIPTION
I am still uncertain as to what exactly is breaking and who is at fault, but this new implementation avoid the issue.

ActiveResource when performing a save would take the whole object and serialize it as JSON (not only the modified values). This seems to be per design and I'm ok with this assuming it is the expected behaviour.

On Shopify side, there seems to be some kind of side effect on certain orders (I'm uncertain of the root cause here) where updating a tag would result in Shopify api to return a 200 OK response with a payload containing the new tag but something behind the scene seems to strip so the following request is no longer having this tag.

This could be a race condition of some kind when multiple properties are "updated" all at once, or some other behaviour I cannot diagnose since it is not visible from my end.

All that to say, this PR "fixes" the problem (or at least avoid) experienced by Triggerify.